### PR TITLE
Handle exception when querying github integrations without GITHUB_TOKEN

### DIFF
--- a/lib/backends/github.js
+++ b/lib/backends/github.js
@@ -179,6 +179,13 @@ module.exports = class GitHubBackend {
 
         return integration
       }))
+    }).catch((error) => {
+      if (error.code === 404) {
+        debug('Cannot get the list of integrations (have you passed $GITHUB_TOKEN ?)')
+        return null
+      }
+
+      throw error
     })
   }
 }


### PR DESCRIPTION
Change-Type: patch
Fixes #8